### PR TITLE
Fixing response syntax for compatibility with Guzzle 6.

### DIFF
--- a/src/Controller/WeatherController.php
+++ b/src/Controller/WeatherController.php
@@ -29,9 +29,9 @@ class WeatherController extends ControllerBase {
             // use our theme function to render twig template
             $element = array(
                 '#theme' => 'phparch_current_weather',
-                '#location' => $weather['name'],
-                '#temperature' => $weather['main']['temp'],
-                '#description' => $weather['weather'][0]['description'],
+                '#location' => $weather->name,
+                '#temperature' => $weather->main->temp,
+                '#description' => $weather->weather[0]->description,
                 '#zipcode' => $zipcode,
             );
 
@@ -59,7 +59,7 @@ class WeatherController extends ControllerBase {
         );
 
         if (200 == $request->getStatusCode()) {
-            return $request->json();
+            return json_decode($request->getBody());
         }
     }
 }


### PR DESCRIPTION
Guzzle 6 (now required by Drupal 8) no longer supports the `json()` method on the response object. When trying this module with a fresh install of Drupal 8, I got the following error:

```
NOTICE: PHP message: PHP Fatal error:  Call to undefined method GuzzleHttp\Psr7\Response::json() in /var/www/html/modules/phparch/src/Controller/WeatherController.php on line 62
```

This updates module code to resolve the error.
